### PR TITLE
Update Squeezelite scripts for FPP 7.x

### DIFF
--- a/Media/SqueezeLiteStart.sh
+++ b/Media/SqueezeLiteStart.sh
@@ -82,11 +82,11 @@ sudo /usr/bin/squeezelite -z ${SB_SERVER} ${SL_HOSTNAME} ${OTHER_ARGS}
 #
 #play 40
 #
-do_play () {	 
+do_play () {
     # This function only works if the Squeezebox server IP is set
     if  [ ! -z "$SERVER" ]; then
       echo "Sending play command to Squeezebox server"
-      printf "$HOSTNAME play\nexit\n" | nc $SERVER $SB_SERVER_CLI_PORT > /dev/null						 
+      printf "$HOSTNAME play\nexit\n" | nc $SERVER $SB_SERVER_CLI_PORT > /dev/null
     else
       echo "The IP address of the Squeezebox server is not set (variable: SERVER should be set). This is needed for the play function."
     fi

--- a/Media/SqueezeLiteStop.sh
+++ b/Media/SqueezeLiteStop.sh
@@ -3,5 +3,5 @@
 # SqueezeLiteStop.sh - Stop a running squeezelite instance
 ##############################################################################
 
-sudo killall -9 squeezelite-armv6hf
+sudo killall -9 squeezelite
 

--- a/index.csv
+++ b/index.csv
@@ -31,8 +31,8 @@ GPIO,GPIO-On.sh,Turn ON a GPIO Output,v2.0.0
 GPIO,GPIO-Off.sh,Turn OFF a GPIO Output,v2.0.0
 GPIO,LongShort-ButtonPressed.sh,Script 1 of 2 to allow a single GPIO input to serve two functions.  Needs LongShort-ButtonReleased.sh as well.,v1.0
 GPIO,LongShort-ButtonReleased.sh,Script 2 of 2 to allow a single GPIO input to serve two functions.  Needs LongShort-ButtonPressed.sh as well.,v1.0
-Media,SqueezeLiteStart.sh,Start a SqueezeLite player,v0.4.0,v6.9
-Media,SqueezeLiteStop.sh,Stop a running SqueezeLite player,v0.4.0,v6.9
+Media,SqueezeLiteStart.sh,Start a SqueezeLite player,v7.0
+Media,SqueezeLiteStop.sh,Stop a running SqueezeLite player,v7.0
 Media,MP3StreamerStart.sh,Start A Internet Stream,v0.4.0,v6.9
 Media,MP3StreamerStop.sh,Stop A Running Internet Stream,v0.4.0,v6.9
 Media,PlayVideo.sh,Play a video,v0.4.0,v5.9


### PR DESCRIPTION
-Update install instructions for packaged version of squeezelite available for bullseye 
-fix autoplay
-add functionality for play/pause

Note that changes in the scripts break compatibility with versions of FPP older than 7.0 that referenced a now broken link to a pre-built squeezelite binary with a different filename.